### PR TITLE
fix and make the snow plates ABM configurable

### DIFF
--- a/weather/settingtypes.txt
+++ b/weather/settingtypes.txt
@@ -1,0 +1,8 @@
+# Fast computer ABM
+#
+# The “fast computer ABM” controls if snow covers will be placed
+# on the ground when `weather:snow` is set. This needs a better
+# computer and should not be used if the performance drops too
+# much. It is advised not to enable this on servers and it is
+# disbaled by default
+weather_fast_pc (Snow covers for fast PCs) bool false

--- a/weather/snow.lua
+++ b/weather/snow.lua
@@ -26,23 +26,25 @@ minetest.register_node("weather:snow_cover", {
 	drop = {}
 })
 
---[[ Enable this section if you have a very fast PC
-minetest.register_abm({
-	nodenames = {"group:crumbly", "group:snappy", "group:cracky", "group:choppy"},
-	neighbors = {"default:air"},
-	interval = 10.0,
-	chance = 80,
-	action = function (pos, node, active_object_count, active_object_count_wider)
-		if weather == "snow" then
-			if minetest.registered_nodes[node.name].drawtype == "normal"
-			or minetest.registered_nodes[node.name].drawtype == "allfaces_optional" then
-				local np = vector.add(pos, {x=0, y=1, z=0})
-				if minetest.env:get_node_light(np, 0.5) == 15
-				and minetest.env:get_node(np).name == "air" then
-					minetest.env:add_node(np, {name="weather:snow_cover"})
+-- Snow cover ABM when weather_fast_pc setting is set to `true`
+if minetest.is_yes(minetest.settings:get_bool('weather_fast_pc')) then
+	minetest.log('action', '[weather] Loaded fast computer ABM (snow covers when weather:snow is set)')
+	minetest.register_abm({
+		nodenames = {"group:crumbly", "group:snappy", "group:cracky", "group:choppy"},
+		neighbors = {"default:air"},
+		interval = 10.0,
+		chance = 80,
+		action = function (pos, node, active_object_count, active_object_count_wider)
+			if weather.type == "weather:snow" then
+				if minetest.registered_nodes[node.name].drawtype == "normal"
+				or minetest.registered_nodes[node.name].drawtype == "allfaces_optional" then
+					local np = vector.add(pos, {x=0, y=1, z=0})
+					if minetest.env:get_node_light(np, 0.5) == 15
+					and minetest.env:get_node(np).name == "air" then
+						minetest.env:add_node(np, {name="weather:snow_cover"})
+					end
 				end
 			end
 		end
-	end
-})
-]]
+	})
+end

--- a/weather/snow.lua
+++ b/weather/snow.lua
@@ -34,7 +34,7 @@ if minetest.is_yes(minetest.settings:get_bool('weather_fast_pc')) then
 		neighbors = {"default:air"},
 		interval = 10.0,
 		chance = 80,
-		action = function (pos, node, active_object_count, active_object_count_wider)
+		action = function (pos, node)
 			if weather.type == "weather:snow" then
 				if minetest.registered_nodes[node.name].drawtype == "normal"
 				or minetest.registered_nodes[node.name].drawtype == "allfaces_optional" then


### PR DESCRIPTION
The fast PCs ABM was broken and never triggered because a wrong `if` clause.

The second thing this PR addresses is configurability. Having to change code is never a good idea to configure something. Thus this PR adds a `settingtypes.txt` for convenient configuration through the client and the necessary functionality to turn the ABM on when `weather_fast_pc` is boolean `true`.